### PR TITLE
Remove socket file

### DIFF
--- a/systemd/docker-quobyte-plugin.service
+++ b/systemd/docker-quobyte-plugin.service
@@ -2,8 +2,8 @@
 Description=Docker Quobyte Plugin
 Documentation=https://github.com/johscheuer/go-quobyte-docker
 Before=docker.service
-After=network.target docker-quobyte-plugin.socket
-Requires=docker-quobyte-plugin.socket docker.service
+After=network.target docker.service
+Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/quobyte/docker-quobyte.env

--- a/systemd/docker-quobyte-plugin.socket
+++ b/systemd/docker-quobyte-plugin.socket
@@ -1,9 +1,0 @@
-[Unit]
-Description=Docker Quobyte plugin Socket for the API
-Documentation=https://github.com/quobyte/docker-volume
-
-[Socket]
-ListenStream=/var/run/docker/plugins/quobyte.sock
-
-[Install]
-WantedBy=sockets.target


### PR DESCRIPTION
Since we changed from Python to go and use the go-plugin-helper from Docker we don't need to create the Unix socket anymore it will be automatically created, see [here](https://docs.docker.com/engine/extend/plugin_api/#/systemd-socket-activation)
