### PR TITLE
Fix build and add ldflags for smaller binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ OS              | Docker Version
 --------------- | :------------:
 CentOS 7.2      |     1.10.3
 Ubuntu 16.04    |     1.11.2
+Ubuntu 16.04    |     1.12.0
 CoreOS 1097.0.0 |     1.11.2
 
 ## Build
@@ -21,19 +22,19 @@ $ go get -u github.com/quobyte/docker-volume
 ### Linux
 
 ```
-$ go build -o bin/docker-quobyte-plugin .
+$ go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
 ```
 
 ### OSX/MacOS
 
 ```
-$ GOOS=linux GOARCH=amd64 go build -o bin/docker-quobyte-plugin .
+$ GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
 ```
 
 ### Docker
 
 ```
-$ docker run --rm -v "$GOPATH":/work -e "GOPATH=/work" -w /work/src/github.com/quobyte/docker-volume golang:1.6 go build -v -o bin/quobyte-docker-plugin
+$ docker run --rm -v "$GOPATH":/work -e "GOPATH=/work" -w /work/src/github.com/quobyte/docker-volume golang:1.6 go build -v -ldflags "-s -w" -o bin/quobyte-docker-plugin
 ```
 
 ## Usage

--- a/quobyte_driver.go
+++ b/quobyte_driver.go
@@ -62,7 +62,7 @@ func (driver quobyteDriver) Remove(request volume.Request) volume.Response {
 	return volume.Response{Err: ""}
 }
 
-func (driver quobyteDriver) Mount(request volume.Request) volume.Response {
+func (driver quobyteDriver) Mount(request volume.MountRequest) volume.Response {
 	driver.m.Lock()
 	defer driver.m.Unlock()
 	mPoint := filepath.Join(driver.quobyteMount, request.Name)
@@ -78,7 +78,7 @@ func (driver quobyteDriver) Path(request volume.Request) volume.Response {
 	return volume.Response{Mountpoint: filepath.Join(driver.quobyteMount, request.Name)}
 }
 
-func (driver quobyteDriver) Unmount(request volume.Request) volume.Response {
+func (driver quobyteDriver) Unmount(request volume.UnmountRequest) volume.Response {
 	return volume.Response{}
 }
 


### PR DESCRIPTION
I added some ldflags to get a smaller binary at compile time (compare 8MB - 4MB). Also I adjusted the Quobyte Driver to match the new Interface (https://github.com/docker/go-plugins-helpers/pull/56).
