### PR TITLE
Added version into main.go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - go get -u .
 - go fmt ./...
 - go vet $(go list ./...)
-- CGO_ENABLED=0 go build -ldflags "-s -w" -a -installsuffix cgo -o bin/docker-quobyte-plugin
+- CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match) -X main.revision=$(git log -1 --format=%h)" -a -installsuffix cgo -o bin/docker-quobyte-plugin
   .
 deploy:
   provider: releases

--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@ import (
 
 const quobyteID string = "quobyte"
 
+var (
+	version  string
+	revision string
+)
+
 func main() {
 	quobyteMountPath := flag.String("path", "/run/docker/quobyte/mnt", "Path where Quobyte is mounted on the host")
 	quobyteMountOptions := flag.String("options", "-o user_xattr", "Fuse options to be used when Quobyte is mounted")
@@ -20,7 +25,13 @@ func main() {
 	quobyteRegistry := flag.String("registry", "localhost:7861", "URL to the registry server(s) in the form of host[:port][,host:port] or SRV record name")
 
 	group := flag.String("group", "root", "Group to create the unix socket")
+	showVersion := flag.Bool("version", false, "Shows version string")
 	flag.Parse()
+
+	if *showVersion {
+		log.Printf("Version: %s - Revision: %s\n", version, revision)
+		return
+	}
 
 	if err := os.MkdirAll(*quobyteMountPath, 0555); err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
Add `version` and `revision` string to allow users to validate their installed version.

Sample output: 

``` bash
$ bin/docker-quobyte-plugin -version
2016/08/20 11:32:58 Version: master - Revision: 8aa94b7
```
