### PR TITLE
Update Readme to be more user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,37 +13,41 @@ Ubuntu 16.04    |     1.11.2
 Ubuntu 16.04    |     1.12.0
 CoreOS 1097.0.0 |     1.11.2
 
-## Build
+## Setup
 
-Get the code
+### Binary
 
-```
-$ go get -u github.com/quobyte/docker-volume
-```
+Download the binary and the systemd files from the [releases](https://github.com/quobyte/docker-volume/releases) page. To download version `1.1` of this plugin run the following step:
 
-### Dependency Management
-
-For the dependency management we use [golang dep](https://github.com/golang/dep)
-
-### Linux
-
-```
-$ go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
+```bash
+curl -LO https://github.com/quobyte/docker-volume/releases/download/v1.1/docker-quobyte-plugin.tar.gz
+tar xfz docker-quobyte-plugin.tar.gz
 ```
 
-### OSX/MacOS
+### Create a user in Quobyte for the plug-in:
+
+This step is optional.
 
 ```
-$ GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
+$ qmgmt -u <api-url> user config add docker <email>
 ```
 
-### Docker
+### Systemd Files
+
+Install systemd files and set your variables in systemd/docker-quobyte.env.sample
 
 ```
-$ docker run --rm -v "$GOPATH":/work -e "GOPATH=/work" -w /work/src/github.com/quobyte/docker-volume golang:1.8 go build -v -ldflags "-s -w" -o bin/quobyte-docker-plugin
+$ cp systemd/docker-quobyte.env.sample /etc/quobyte/docker-quobyte.env
+$ cp bin/docker-quobyte-plugin /usr/local/bin/
+$ cp systemd/docker-quobyte-plugin.service /lib/systemd/system
+
+$ systemctl daemon-reload
+$ systemctl start docker-quobyte-plugin
+$ systemctl enable docker-quobyte-plugin
+$ systemctl status docker-quobyte-plugin
 ```
 
-## Usage
+### Usage
 
 ```
 $ bin/docker-quobyte-plugin -h
@@ -62,31 +66,6 @@ Usage of /opt/bin/docker-quobyte-plugin:
         URL to the registry server(s) in the form of host[:port][,host:port] or SRV record name (default "localhost:7861")
   -user string
         User to connect to the Quobyte API server (default "root")
-```
-
-## Setup
-
-### Create a user in Quobyte for the plug-in:
-
-This step is optional.
-
-```
-$ qmgmt -u <api-url> user config add docker <email>
-```
-
-### systemd
-
-Install systemd files and set your variables in systemd/docker-quobyte.env.sample
-
-```
-$ cp systemd/docker-quobyte.env.sample /etc/quobyte/docker-quobyte.env
-$ cp bin/docker-quobyte-plugin /usr/local/bin/
-$ cp systemd/docker-quobyte-plugin.service /lib/systemd/system
-
-$ systemctl daemon-reload
-$ systemctl start docker-quobyte-plugin
-$ systemctl enable docker-quobyte-plugin
-$ systemctl status docker-quobyte-plugin
 ```
 
 ## Examples
@@ -115,4 +94,36 @@ $ docker volume ls
 
 ```
 $ docker run --volume-driver=quobyte -v <volumename>:/vol busybox sh -c 'echo "Hello World" > /vol/hello.txt'
+```
+
+## Development
+
+### Build
+
+Get the code
+
+```
+$ go get -u github.com/quobyte/docker-volume
+```
+
+#### Dependency Management
+
+For the dependency management we use [golang dep](https://github.com/golang/dep)
+
+#### Linux
+
+```
+$ go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
+```
+
+#### OSX/MacOS
+
+```
+$ GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o bin/docker-quobyte-plugin .
+```
+
+#### Docker
+
+```
+$ docker run --rm -v "$GOPATH":/work -e "GOPATH=/work" -w /work/src/github.com/quobyte/docker-volume golang:1.8 go build -v -ldflags "-s -w" -o bin/quobyte-docker-plugin
 ```


### PR DESCRIPTION
We should put the Development topics at the end of the readme and help "non-developer" users to easily understand how to setup and use the Plugin (without the need to compile the plugin by their own).