### PR TITLE
Bumps the API client version to v0.1.1

### DIFF
--- a/vendor/github.com/quobyte/api/rpc_client.go
+++ b/vendor/github.com/quobyte/api/rpc_client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -106,5 +107,8 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Printf("Warning: HTTP status code for request is %s\n", strconv.Itoa(resp.StatusCode))
+	}
 	return decodeResponse(resp.Body, &response)
 }


### PR DESCRIPTION
This adds warnings about non-successful HTTP status codes being returned to the API client.