### PR TITLE
Allow setting the tenant id for a volume operation, add options list

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ Usage of bin/docker-quobyte-plugin:
  __Please note__ that using the environment file for setting the password is strongly encouraged over using the cli parameter.
 
 
+The following plugin specific options can be injected through the docker client:
+
+```
+  --opt user=<default user for the given volume>
+  --opt group=<default group for the given volume>
+  --opt configuration_name=<volume configuration name>
+  --opt tenant_id=<tenant id for the given volume operation>
+```
+
+
 ## Examples
 
 ### Create a volume

--- a/quobyte_driver.go
+++ b/quobyte_driver.go
@@ -57,6 +57,9 @@ func (driver quobyteDriver) Create(request volume.Request) volume.Response {
 	if conf, ok := request.Options["configuration_name"]; ok {
 		configurationName = conf
 	}
+	if tenant, ok := request.Options["tenant_id"]; ok {
+		tenantID = tenant
+	}
 
 	if _, err := driver.client.CreateVolume(&quobyte_api.CreateVolumeRequest{
 		Name:              request.Name,


### PR DESCRIPTION
Allows setting tenant id per volume operation and adds a list of
supported options to the Readme documentation.

Closes-Bug: #31