### PR TITLE
Set open file limit for systemd service to 16384

### DIFF
--- a/systemd/docker-quobyte-plugin.service
+++ b/systemd/docker-quobyte-plugin.service
@@ -8,6 +8,7 @@ Requires=docker.service
 [Service]
 EnvironmentFile=/etc/quobyte/docker-quobyte.env
 ExecStart=/usr/local/bin/docker-quobyte-plugin
+LimitNOFILE=16384
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sets the required default ulimit for open files in the sytemd service config.